### PR TITLE
Sending cache-control public for counter_last endpoint

### DIFF
--- a/api/routes/counter_last.py
+++ b/api/routes/counter_last.py
@@ -103,7 +103,9 @@ class RussiaCounterLastResource(Resource):
     @routes_api.expect(parser)
     def get(self):
         params = RussiaCounterLastResource.parser.parse_args()
-        return self.get_from_params(params)
+        response = self.get_from_params(params)
+        response.headers['Cache-Control'] = 'public'
+        return response
 
     def get_from_params(self, params):
         # original parameters (before any potential modifications)

--- a/api/routes/counter_last_tmp.py
+++ b/api/routes/counter_last_tmp.py
@@ -102,9 +102,12 @@ class RussiaCounterLastResource(Resource):
     def get(self):
         params = RussiaCounterLastResource.parser.parse_args()
         counter_last = self.get_from_params(params)
-        return self.build_response(
+        response = self.build_response(
             counter_last=counter_last, format=params.get("format")
         )
+
+        response.headers['Cache-Control'] = 'public'
+        return response
 
     def get_from_params(self, params):
         # original parameters (before any potential modifications)


### PR DESCRIPTION
Added response header "Cache-Control=public" to /v0/counter_last and /v0/counter_last_tmp