### PR TITLE
Update PR workflows to avoid double testing

### DIFF
--- a/.github/workflows/russia-api-test.yml
+++ b/.github/workflows/russia-api-test.yml
@@ -3,11 +3,8 @@ name: russia-api-test
 
 on:
   pull_request:
-    types: [opened, reopened]
     branches:
       - master
-  push:
-    branches-ignore: master
 
 jobs:
   build:

--- a/.github/workflows/russia-engine-test.yml
+++ b/.github/workflows/russia-engine-test.yml
@@ -3,7 +3,6 @@ name: russia-engine-test
 
 on:
   pull_request:
-    types: [opened, reopened]
     branches:
       - master
 


### PR DESCRIPTION
Looking at [the docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the default events for `pull_request` are "when a pull request is opened or reopened or when the head branch of the pull request is updated".

I tried to do this with the following but that caused the tests to run twice on any push.
```yml
  push:
    branches-ignore: master
```