### PR TITLE
Add kpler vessels to ships table

### DIFF
--- a/engine/kpler_scraper/upload.py
+++ b/engine/kpler_scraper/upload.py
@@ -4,6 +4,7 @@ import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
+from ..ship import fill
 
 from base.models import (
     DB_TABLE_KPLER_PRODUCT,
@@ -141,6 +142,8 @@ def upload_vessels(vessels, ignore_if_copy_failed=False):
         return None
 
     vessels = vessels.drop_duplicates(subset=["id"])
+
+    fill(vessels.imo.unique())
 
     if len(vessels) > 0:
         try:


### PR DESCRIPTION
Adss the kpler vessels to ships table.

While I've done it as part of the `upload_vessels` function, it could be a pulled out into its own function taking in vessels and uploading the ships - I thought this was a better place for it, however..