### PR TITLE
Fix kpler_trade endpoint

### DIFF
--- a/api/tests/test_kpler.py
+++ b/api/tests/test_kpler.py
@@ -814,20 +814,20 @@ def test_kpler_trade_ship_insurer(app):
         SINGLE_SHIP_UNKNOWN_INSURER = {
             "trade_id": 3108824,
             "ship_insurer_names": ["unknown"],
-            "ship_insurer_iso2s": [None],
-            "ship_insurer_regions": [None],
+            "ship_insurer_iso2s": ["unknown"],
+            "ship_insurer_regions": ["unknown"]
         }
         SINGLE_SHIP_WITH_INSURER = {
             "trade_id": 794454,
             "ship_insurer_names": ["North of England P&I Association"],
             "ship_insurer_iso2s": ["GB"],
-            "ship_insurer_regions": ["Global"],
+            "ship_insurer_regions": ["United Kingdom"],
         }
         MULTI_SHIP_ONE_INSURER = {
             "trade_id": 17145711,
             "ship_insurer_names": ["Assuranceforeningen Gard - Norway"],
             "ship_insurer_iso2s": ["NO"],
-            "ship_insurer_regions": ["Global"],
+            "ship_insurer_regions": ["Others"],
         }
         MULTI_SHIP_MULTIPLE_INSURERS = {
             "trade_id": 17069592,
@@ -835,9 +835,9 @@ def test_kpler_trade_ship_insurer(app):
                 "Britannia Steamship insurance Association Ld",
                 "UK P&I Club",
             ],
-            "ship_insurer_iso2s": ["GB"],
+            "ship_insurer_iso2s": ["GB", "GB"],
             "ship_insurer_regions": [
-                "Global",
+                "United Kingdom",
                 "United Kingdom",
             ],
         }
@@ -890,24 +890,24 @@ def test_kpler_trade_ship_owner(app):
             "trade_id": 804124,
             "ship_owner_names": ["CORAL ENERGY SHIPPING BV"],
             "ship_owner_iso2s": ["NO"],
-            "ship_owner_regions": ["Global"],
+            "ship_owner_regions": ["Others"],
         }
         MULTI_SHIP_ONE_OWNER = {
             "trade_id": 16468265,
             "ship_owner_names": ["ARAB MARITIME PETROLEUM TRANS"],
             "ship_owner_iso2s": ["KW"],
-            "ship_owner_regions": ["Global", "Others"],
+            "ship_owner_regions": ["Others"],
         }
         MULTI_SHIP_MULTIPLE_OWNERS = {
             "trade_id": 794079,
             "ship_owner_names": [
-                "HAI FENG 1716 LTD",
                 "HAI KUO SHIPPING 1605 LTD",
+                "HAI FENG 1716 LTD",
             ],
             "ship_owner_iso2s": ["GR", "NO"],
             "ship_owner_regions": [
-                "EU28",
-                "Global",
+                "EU",
+                "Others",
             ],
         }
 

--- a/misc/equasis_accounts/main.py
+++ b/misc/equasis_accounts/main.py
@@ -16,8 +16,8 @@ from decouple import config
 REGISTRATION_URL = "https://www.equasis.org/EquasisWeb/public/Registration?fs=ConditionsRegistration"
 RECAPTCHA_SELECTOR="iframe[title=reCAPTCHA]"
 
-START_RANGE = 160
-END_RANGE = 200
+START_RANGE = 327
+END_RANGE = 328
 
 PASSWORD = config('EQUASIS_PASSWORD')
 
@@ -30,9 +30,7 @@ if __name__ == "__main__":
     options.add_argument("--disable-dev-shm-usage")
     options.binary_location = "/sbin/chromium"
 
-    service = Service(ChromeDriverManager().install())
-
-    browser = webdriver.Chrome(service=service, options=options)
+    browser = webdriver.Chrome(service=Service("chromedriver"), options=options)
 
     for i in range(START_RANGE, END_RANGE):
         browser.switch_to.new_window('tab')


### PR DESCRIPTION
Makes sure we join on `kpler_trade.flow_id` and `kpler_trade.id` all the way down and only join to the valid ships for each trade - maintaining the aggregation order.

To get reasonable performance, I had to force the CTEs to be `materialized` (we precompute and make a copy). Without this, Postgres ended up materialising a different result which caused a 6 hour long step in the query (likely because it was materialising too much).