### PR TITLE
Use original order

### DIFF
--- a/api/tests/test_kpler.py
+++ b/api/tests/test_kpler.py
@@ -834,10 +834,10 @@ def test_kpler_trade_ship_insurer(app):
         }
         MULTI_SHIP_MULTIPLE_INSURERS = {
             "trade_id": 17069592,
-            "vessel_imos": ['9831816', '9907718'],
+            "vessel_imos": ['9907718', '9831816'],
             "ship_insurer_names": [
-                "Britannia Steamship insurance Association Ld",
                 "UK P&I Club",
+                "Britannia Steamship insurance Association Ld",
             ],
             "ship_insurer_iso2s": ["GB", "GB"],
             "ship_insurer_regions": [


### PR DESCRIPTION
This should now use the original ship order for arrayed per-ship related values.