### PR TITLE
Convert kpler tests to fetch live

### DIFF
--- a/engine/integrity/__init__.py
+++ b/engine/integrity/__init__.py
@@ -1,0 +1,1 @@
+from .checker import IntegrityCheckResult, IntegrityCheckDefinition, IntegrityStep, check

--- a/engine/integrity/check_kpler_trade.py
+++ b/engine/integrity/check_kpler_trade.py
@@ -1,0 +1,129 @@
+import requests
+from engines.kpler_scraper.scraper_flow import KplerFlowScraper
+from kpler.sdk import FlowsSplit, FlowsPeriod, FlowsMeasurementUnit
+from decouple import config
+import datetime as dt
+from base.utils import to_datetime
+import pandas as pd
+import numpy as np
+
+FST_API_URL = config("FOSSIL_SHIPMENT_TRACKER_API_URL")
+FST_API_KEY = config("API_KEY")
+
+scraper = KplerFlowScraper()
+
+product_info = {
+    "Crude/Co": {
+        "platform": "liquids",
+        "type": "group",
+    },
+    "LNG": {"platform": "lng", "type": "group"},
+}
+
+
+def test_kpler_trades(date_from=None, product=None, origin_iso2=None):
+
+    start_date = to_datetime(date_from).date()
+    end_date = (dt.datetime.now().replace(day=1) - dt.timedelta(days=1)).date()
+
+    flows = get_flows_from_kpler(
+        product=product, origin_iso2=origin_iso2, date_from=start_date, date_to=end_date
+    )
+
+    aggregated_trades = get_aggregated_trades_from_api(
+        product=product, origin_iso2=origin_iso2, date_from=start_date, date_to=end_date
+    )
+
+    comparison = compare_flows_to_trades(flows, aggregated_trades)
+
+    assert all(comparison["ok"]), (
+        f"Incorrect values for kpler trade for {product} "
+        + f"from {origin_iso2} after {date_from}:\n"
+        + format_failed(comparison[~comparison.ok])
+    )
+
+
+def compare_flows_to_trades(flows, aggregated_trades):
+    comparison = pd.merge(
+        flows,
+        aggregated_trades,
+        how="outer",
+        on=["month", "group", "to_iso2"],
+        suffixes=(".expected", ".actual"),
+    )
+
+    # We don't keep track of trades with unknown destinations.
+    comparison = comparison[pd.notnull(comparison.to_iso2)]
+
+    comparison["ok"] = np.isclose(
+        comparison["value_tonne.expected"], comparison["value_tonne.actual"], rtol=0.01
+    )
+
+    return comparison
+
+
+def get_flows_from_kpler(product, origin_iso2, date_from, date_to):
+    df = scraper.get_flows(
+        product_info[product]["platform"],
+        origin_iso2=origin_iso2,
+        product=product,
+        granularity=FlowsPeriod.Monthly,
+        unit=FlowsMeasurementUnit.T,
+        date_from=date_from,
+        date_to=date_to,
+        split=FlowsSplit.DestinationCountries,
+    )
+
+    column_selector = {
+        "date": "month",
+        "value": "value_tonne",
+        "product": "group",
+        "to_iso2": "to_iso2",
+    }
+
+    renamed_df = df.rename(columns=column_selector)[[*column_selector.values()]]
+    renamed_df["month"] = renamed_df["month"].map(lambda x: x.isoformat()[:10])
+
+    return renamed_df
+
+
+def get_aggregated_trades_from_api(product, origin_iso2, date_from, date_to):
+
+    product_type = product_info[product]["type"]
+
+    params = {
+        "api_key": FST_API_KEY,
+        product_type: product,
+        "origin_iso2": origin_iso2,
+        "aggregate_by": f"origin_month,group,destination_iso2",
+        "date_from": date_from.isoformat(),
+        "date_to": date_to.isoformat(),
+        "format": "json",
+    }
+
+    response = requests.get(FST_API_URL + "/v1/kpler_trade", params=params)
+
+    column_selector = {
+        "month": "month",
+        "value_tonne": "value_tonne",
+        "group": "group",
+        "destination_iso2": "to_iso2",
+    }
+
+    df = pd.DataFrame(response.json()["data"]).rename(columns=column_selector)[
+        [*column_selector.values()]
+    ]
+
+    df["month"] = df["month"].map(lambda x: x[:10])
+
+    return df
+
+
+def format_failed(failed):
+    format_number = lambda n: f"{round(n / 1e3, 3)}kt"
+    row_to_reason = lambda row: (
+        f" - For {row['month']}, "
+        + f"expected {format_number(row['value_tonne.expected'])} "
+        + f"but got {format_number(row['value_tonne.actual'])}."
+    )
+    return "\n".join(failed.apply(row_to_reason, axis=1))

--- a/engine/integrity/checker.py
+++ b/engine/integrity/checker.py
@@ -42,6 +42,9 @@ class IntegrityCheckDefinition:
             return IntegrityCheckResult(self, error=e, tb=tb)
 
 
+KPLER_CHECKER_DATE_FROM = "2021-01-01"
+
+
 class IntegrityStep(Enum):
     SHIPMENTS = IntegrityCheckDefinition("shipments", test_shipment_table)
     SHIPMENT_PORTCALL = IntegrityCheckDefinition(
@@ -60,15 +63,51 @@ class IntegrityStep(Enum):
     INSURER = IntegrityCheckDefinition("pricing positive", test_insurer)
     KPLER_TRADE_CRUDE = IntegrityCheckDefinition(
         "Kpler trade crude",
-        lambda: test_kpler_trades(date_from="2022-01-01", product="Crude/Co", origin_iso2="RU"),
+        lambda: test_kpler_trades(
+            date_from=KPLER_CHECKER_DATE_FROM,
+            product=KplerCheckerProducts.CRUDE,
+            origin_iso2="RU",
+        ),
+    )
+    KPLER_TRADE_LNG = IntegrityCheckDefinition(
+        "Kpler trade LNG",
+        lambda: test_kpler_trades(
+            date_from=KPLER_CHECKER_DATE_FROM,
+            product=KplerCheckerProducts.LNG,
+            origin_iso2="RU",
+        ),
+    )
+    KPLER_TRADE_GASOIL_DIESEL = IntegrityCheckDefinition(
+        "Kpler trade Gasoil/Diesel",
+        lambda: test_kpler_trades(
+            date_from=KPLER_CHECKER_DATE_FROM,
+            product=KplerCheckerProducts.GASOIL_DIESEL,
+            origin_iso2="RU",
+        ),
+    )
+    KPLER_TRADE_METALLURGICAL_COAL = IntegrityCheckDefinition(
+        "Kpler trade Coal",
+        lambda: test_kpler_trades(
+            date_from=KPLER_CHECKER_DATE_FROM,
+            product=KplerCheckerProducts.METALLURGICAL_COAL,
+            origin_iso2="RU",
+        ),
+    )
+    KPLER_TRADE_THERMAL_COAL = IntegrityCheckDefinition(
+        "Kpler trade Coal",
+        lambda: test_kpler_trades(
+            date_from=KPLER_CHECKER_DATE_FROM,
+            product=KplerCheckerProducts.THERMAL_COAL,
+            origin_iso2="RU",
+        ),
     )
 
     def run_test(self):
         return self.value.run_test()
 
-    @property
-    def name(self):
-        return self.name
+    @classmethod
+    def get_kpler_checks(cls):
+        return [step for step in IntegrityStep if step.name.startswith("KPLER_TRADE_")]
 
 
 def check(steps=[step for step in IntegrityStep]):
@@ -81,5 +120,5 @@ def check(steps=[step for step in IntegrityStep]):
         failures = "\n------------\n".join([result.format_error() for result in failed_results])
         logger_slack.error(f"Integrity checks failed: {failures}")
         notify_engineers("Please check error")
-
-    logger_slack.info(f"All integrity checks passed")
+    else:
+        logger_slack.info(f"All integrity checks passed")

--- a/engine/integrity/checker.py
+++ b/engine/integrity/checker.py
@@ -1,0 +1,85 @@
+from enum import Enum
+import traceback
+from api.app import app
+from base.logger import logger_slack, logger, notify_engineers
+
+from api.tests import test_counter
+
+from .checks import *
+
+
+class IntegrityCheckResult:
+    def __init__(self, step, error=None, tb=None):
+        self.step = step
+        self.error = error
+        self.tb = tb
+
+    @property
+    def success(self):
+        return self.error == None
+
+    @property
+    def name(self):
+        return self.step.name
+
+    def format_error(self):
+        return f"Integrity check {self.name} failed with error: {self.tb}"
+
+
+class IntegrityCheckDefinition:
+    def __init__(self, name, test):
+        self.name = name
+        self.test = test
+
+    def run_test(self):
+        logger.info(f"Checking integrity: {self.name}")
+        try:
+            self.test()
+            return IntegrityCheckResult(self)
+        except AssertionError as e:
+            logger.info(f"Checking integrity {self.name} - failure")
+            tb = traceback.format_exc()
+            return IntegrityCheckResult(self, error=e, tb=tb)
+
+
+class IntegrityStep(Enum):
+    SHIPMENTS = IntegrityCheckDefinition("shipments", test_shipment_table)
+    SHIPMENT_PORTCALL = IntegrityCheckDefinition(
+        "shipment portcall", test_shipment_portcall_integrity
+    )
+    PORTCALL_RELATIONSHIP = IntegrityCheckDefinition(
+        "portcall relationship", test_portcall_relationship
+    )
+    BERTHS = IntegrityCheckDefinition("berths", test_berths)
+    COUNTER = IntegrityCheckDefinition(
+        "counter", lambda: test_counter.test_counter_against_voyage(app)
+    )
+    PRICING = IntegrityCheckDefinition(
+        "pricing positive", lambda: test_counter.test_pricing_gt0(app)
+    )
+    INSURER = IntegrityCheckDefinition("pricing positive", test_insurer)
+    KPLER_TRADE_CRUDE = IntegrityCheckDefinition(
+        "Kpler trade crude",
+        lambda: test_kpler_trades(date_from="2022-01-01", product="Crude/Co", origin_iso2="RU"),
+    )
+
+    def run_test(self):
+        return self.value.run_test()
+
+    @property
+    def name(self):
+        return self.name
+
+
+def check(steps=[step for step in IntegrityStep]):
+    logger_slack.info("Checking integrity")
+
+    results = [step.run_test() for step in steps]
+    failed_results = [result for result in results if not result.success]
+
+    if len(failed_results) > 0:
+        failures = "\n------------\n".join([result.format_error() for result in failed_results])
+        logger_slack.error(f"Integrity checks failed: {failures}")
+        notify_engineers("Please check error")
+
+    logger_slack.info(f"All integrity checks passed")

--- a/engine/integrity/checks.py
+++ b/engine/integrity/checks.py
@@ -12,7 +12,10 @@ from base.models import (
 )
 from base.logger import logger_slack
 
-from .check_kpler_trade import test_kpler_trades
+from .check_kpler_trade import (
+    test_kpler_trades,
+    KplerCheckerProducts,
+)  # pylint: disable=unused-import
 
 
 def test_shipment_portcall_integrity():


### PR DESCRIPTION
Makes kpler integrity checks use live data.

Creates a small framework to run multiple integrity tests - all tests will run and errors will be reported. We can ask the checker only to run certain steps. This will make it easier to report for the status endpoint in the future.